### PR TITLE
fixes for issues #16 and #17

### DIFF
--- a/src/RedisBoost/Core/Channel/RedisChannel.cs
+++ b/src/RedisBoost/Core/Channel/RedisChannel.cs
@@ -103,6 +103,8 @@ namespace RedisBoost.Core.Channel
 		{
 			if (ex != null)
 				tcs.SetException(ProcessException(ex));
+			else if (response == null)
+				tcs.SetException(ProcessException(new ArgumentNullException(nameof(response))));
 			else if (response.ResponseType == ResponseType.Error)
 				tcs.SetException(new RedisException(response.AsError()));
 			else

--- a/src/RedisBoost/Core/Pipeline/RedisPipeline.cs
+++ b/src/RedisBoost/Core/Pipeline/RedisPipeline.cs
@@ -190,8 +190,7 @@ namespace RedisBoost.Core.Pipeline
 
 		private void ItemReceiveProcessDone(bool async, ReceiverAsyncEventArgs args)
 		{
-			if (args.HasError)
-				_pipelineException = args.Error;
+			_pipelineException = args.Error;
 
 			if (_pipelineException != null)
 				_currentReceiveItem.CallBack(_pipelineException, null);


### PR DESCRIPTION
This PR contains fixes for two nullreference exceptions and one ObjectDisposedException.
NullReferenceException occurs on production servers with 24 core intel xeon processors because of the processor cache.
ObjectDisposedException occurs when connecion was lost on callback calling (read from socket after bufer released).