### PR TITLE
Fixed bug occurring when connection string specifies non-zero index and server requires authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ Generated_Code #added for RIA/Silverlight projects
 _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
+/.vs

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
 /.vs
+/packages

--- a/src/RedisBoost/Core/IPrepareSupportRedisClient.cs
+++ b/src/RedisBoost/Core/IPrepareSupportRedisClient.cs
@@ -24,5 +24,9 @@ namespace RedisBoost.Core
 	{
 		ClientState State { get; }
 		Task<IRedisClient> PrepareClientConnection();
-	}
+        /// <summary>
+        /// Whether or not this client has issued a successful AUTH command.
+        /// </summary>
+        bool IsAuthenticated { get; }
+    }
 }

--- a/src/RedisBoost/RedisClient.Connection.cs
+++ b/src/RedisBoost/RedisClient.Connection.cs
@@ -26,7 +26,16 @@ namespace RedisBoost
 	{
 		public Task<string> AuthAsync(string password)
 		{
-			return StatusCommand(RedisConstants.Auth, password.ToBytes());
+			var ret = StatusCommand(RedisConstants.Auth, password.ToBytes());
+            ret.ContinueWith(t =>
+            {
+                if (!t.IsFaulted)
+                {
+                    _isAuthenticated = true;
+                }
+                return t.Result;
+            });
+            return ret;
 		}
 
 		public Task<Bulk> EchoAsync<T>(T message)

--- a/src/RedisBoost/RedisClient.cs
+++ b/src/RedisBoost/RedisClient.cs
@@ -137,10 +137,14 @@ namespace RedisBoost
 		public IRedisSerializer Serializer { get; private set; }
 
 		private int _disposed;
+        private bool _isAuthenticated;
 		private readonly IRedisChannel _channel;
 		private readonly RedisConnectionStringBuilder _connectionStringBuilder;
 
 		ClientState IPrepareSupportRedisClient.State { get { return _channel.State; } }
+
+        bool IPrepareSupportRedisClient.IsAuthenticated {  get { return _isAuthenticated; } }
+
 
 		protected RedisClient(RedisConnectionStringBuilder connectionString, IRedisSerializer serializer)
 		{

--- a/tests/RedisBoost.Tests/App.config
+++ b/tests/RedisBoost.Tests/App.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <connectionStrings>
-    <add name="Redis" connectionString="data source=10.1.1.124:6379;initial catalog=0"/>
+    <add name="Redis" connectionString="data source=70.37.94.203:6379;password=abcd1234;initial catalog=4"/>
+    <!--<add name="Redis" connectionString="data source=10.1.1.124:6379;initial catalog=0"/>-->
   </connectionStrings>
 </configuration>

--- a/tests/RedisBoost.Tests/RedisConnectionStringBuilderTests.cs
+++ b/tests/RedisBoost.Tests/RedisConnectionStringBuilderTests.cs
@@ -22,8 +22,15 @@ namespace RedisBoost.Tests
 		{
 			var cs = new RedisConnectionStringBuilder("data source=127.0.0.1:2312");
 			Assert.AreEqual("127.0.0.1:2312", cs.EndPoint.ToString());
-		}
-		[Test]
+        }
+        [Test]
+        public static void InitializeByConnectionString_PasswordIncluded()
+        {
+            var cs = new RedisConnectionStringBuilder("data source=127.0.0.1:2312; password=\"test-password\"");
+            Assert.AreEqual("test-password", cs.Password);
+            Assert.IsTrue(cs.ContainsKey("password"));
+        }
+        [Test]
 		public static void InitializeByConnectionString_DbIndexIncluded()
 		{
 			var cs = new RedisConnectionStringBuilder("data source=127.0.0.1; initial catalog=23");
@@ -36,5 +43,15 @@ namespace RedisBoost.Tests
 			Assert.AreEqual("127.0.0.1:3242", cs.EndPoint.ToString());
 			Assert.AreEqual(23, cs.DbIndex);
 		}
-	}
+
+        [Test]
+        public static void InitializeByHostPort_WithPassword_ValidConnectionString()
+        {
+            var cs = new RedisConnectionStringBuilder("127.0.0.1", 3242, 23, "some-password");
+            Assert.AreEqual("some-password", cs.Password);
+            Assert.AreEqual("data source=\"127.0.0.1:2312\"; passsword=\"some-password\"", cs.ConnectionString);
+        }
+
+
+    }
 }


### PR DESCRIPTION
When connecting to a server that requires authentication, the PrepareClientConnection method would throw an exception if the database index was greater than zero.  Fixed by adding support for parsing password property from connection string and then using that property to authenticate when it is set.  Also added IsAuthenticated flag, which is used to preserve authentication status when a pooled connection is re-used, avoiding a second call to AUTH.